### PR TITLE
SimulationInput cache reset

### DIFF
--- a/pyinduct/simulation.py
+++ b/pyinduct/simulation.py
@@ -72,7 +72,8 @@ class SimulationInput(object, metaclass=ABCMeta):
         """
         return dict(output=self._res)
 
-    def get_results(self, time_steps, result_key="output", interpolation="nearest", as_eval_data=False):
+    def get_results(self, time_steps, result_key="output",
+                    interpolation="nearest", as_eval_data=False):
         """
         Return results from internal storage for given time steps.
 
@@ -82,10 +83,12 @@ class SimulationInput(object, metaclass=ABCMeta):
         Args:
             time_steps: Time points where values are demanded.
             result_key: Type of values to be returned.
-            interpolation: Interpolation method to use if demanded time-steps are not covered by the storage,
-                see :func:`scipy.interpolate.interp1d` for all possibilities.
-            as_eval_data (bool): Return results as :py:class:`pyinduct.visualization.EvalData`
-                object for straightforward display.
+            interpolation: Interpolation method to use if demanded time-steps 
+                are not covered by the storage, see 
+                :func:`scipy.interpolate.interp1d` for all possibilities.
+            as_eval_data (bool): Return results as 
+                :py:class:`pyinduct.visualization.EvalData` object for 
+                straightforward display.
 
         Return:
             Corresponding function values to the given time steps.
@@ -103,6 +106,18 @@ class SimulationInput(object, metaclass=ABCMeta):
                             name=".".join([self.name, result_key]))
 
         return values
+
+    def clear_cache(self):
+        """
+        Clear the internal value storage.
+        
+        When the same *SimulationInput* is used to perform various simulations,
+        there is no possibility to distinguish between the different runs when
+        *get_results* gets called. Therefore this method can be used to clear
+        the cache.
+        """
+        self._time_storage.clear()
+        self._value_storage.clear()
 
 
 class EmptyInput(SimulationInput):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -110,6 +110,7 @@ class SimulationInputTest(unittest.TestCase):
 
         # run simulation to fill the internal storage
         domain = pi.Domain((0, 10), step=.1)
+        bigger_domain = pi.Domain((-1, 11), step=.1)
         res = sim.simulate_state_space(ss, ic, domain)
 
         # don't return any entries that aren't there
@@ -124,9 +125,25 @@ class SimulationInputTest(unittest.TestCase):
         self.assertIsInstance(ed, np.ndarray)
 
         # return EvalData if corresponding flag is set
-        self.assertIsInstance(u.get_results(domain, as_eval_data=True), pi.EvalData)
+        self.assertIsInstance(u.get_results(domain, as_eval_data=True),
+                              pi.EvalData)
 
-        # TODO interpolation methods and extrapolation errors
+        # raise an error if extrapolation is performed
+        self.assertRaises(ValueError, u.get_results, bigger_domain)
+
+        # storage contains values
+        self.assertTrue(u._time_storage)
+        self.assertTrue(u._value_storage)
+
+        # clear it
+        u.clear_cache()
+
+        # storage should be empty
+        self.assertFalse(u._time_storage)
+        self.assertFalse(u._value_storage)
+
+        # double clearing should work
+        u.clear_cache()
 
 
 class CanonicalFormTest(unittest.TestCase):


### PR DESCRIPTION
This feature makes it possible to use the same input object in several
simulation runs and still distinguish between the stored values.