### PR TITLE
Update eigenfunction test with not working length

### DIFF
--- a/pyinduct/eigenfunctions.py
+++ b/pyinduct/eigenfunctions.py
@@ -995,13 +995,13 @@ class SecondOrderRobinEigenfunction(Function, SecondOrderEigenfunction):
         try:
             om = list(find_roots(characteristic_equation,
                                  [np.array([0]), start_values_imag],
-                                 rtol=1e-3*l, cmplx=True))
+                                 rtol=1e-3 / l, cmplx=True))
         except ValueError:
             om = list()
 
         # search real roots
         om += find_roots(characteristic_equation, [start_values_real],
-                         2 * n_roots, rtol=1e-3*l,
+                         2 * n_roots, rtol=1e-3 / l,
                          cmplx=False).tolist()
 
         # only "real" roots and complex roots with imaginary part != 0
@@ -1024,7 +1024,7 @@ class SecondOrderRobinEigenfunction(Function, SecondOrderEigenfunction):
               if root.real >= 0 and np.isclose(root.imag, 0)]
 
         # delete all around om = 0
-        for i in [ind for ind, val in enumerate(np.isclose(np.array(om),
+        for i in [ind for ind, val in enumerate(np.isclose(np.array(om) * l,
                                                            0,
                                                            atol=1e-4)) if val]:
             om.pop(i)

--- a/pyinduct/eigenfunctions.py
+++ b/pyinduct/eigenfunctions.py
@@ -968,18 +968,6 @@ class SecondOrderRobinEigenfunction(Function, SecondOrderEigenfunction):
                         + ((eta + beta) * (alpha - eta) / omega
                            - omega) * np.sin(omega * l))
 
-        if show_plot:
-            z_real = np.linspace(-15, 15)
-            z_imag = np.linspace(-5, 5)
-            vec_function = np.vectorize(characteristic_equation)
-            plt.plot(z_real, np.real(vec_function(z_real)))
-            plt.plot(z_real, np.imag(vec_function(z_real)))
-            plt.plot(z_imag, np.real(vec_function(z_imag * 1j)))
-            plt.plot(z_imag, np.imag(vec_function(z_imag * 1j)))
-            plt.plot(z_real, np.real(char_eq(z_real)))
-            plt.plot(z_real, np.imag(char_eq(z_real)))
-            plt.show()
-
         # assume 1 root per pi/l (safety factor = 3)
         search_begin = np.pi / l * .1
         search_end = 3 * n_roots * np.pi / l
@@ -989,6 +977,19 @@ class SecondOrderRobinEigenfunction(Function, SecondOrderEigenfunction):
         start_values_imag = np.linspace(search_begin,
                                         search_end,
                                         search_end / np.pi * l * 20)
+
+        if show_plot:
+            vec_function = np.vectorize(characteristic_equation)
+            plt.plot(start_values_real,
+                     np.real(vec_function(start_values_real)))
+            plt.plot(start_values_real,
+                     np.imag(vec_function(start_values_real)))
+            plt.show()
+            plt.plot(start_values_imag * 1j,
+                     np.real(vec_function(start_values_imag * 1j)))
+            plt.plot(start_values_imag * 1j,
+                     np.imag(vec_function(start_values_imag * 1j)))
+            plt.show()
 
         # search imaginary roots
         try:

--- a/pyinduct/eigenfunctions.py
+++ b/pyinduct/eigenfunctions.py
@@ -925,7 +925,8 @@ class SecondOrderRobinEigenfunction(Function, SecondOrderEigenfunction):
     @staticmethod
     def eigfreq_eigval_hint(param, l, n_roots, show_plot=False):
         r"""
-        Return the first *n_roots* eigenfrequencies :math:`\omega` and eigenvalues :math:`\lambda`.
+        Return the first *n_roots* eigenfrequencies :math:`\omega` and
+        eigenvalues :math:`\lambda`.
 
         .. math:: \omega_i = \sqrt{
             - \frac{a_1^2}{4a_2^2}
@@ -935,8 +936,10 @@ class SecondOrderRobinEigenfunction(Function, SecondOrderEigenfunction):
         to the considered eigenvalue problem.
 
         Args:
-            param (array_like): :math:`\big( a_2, a_1, a_0, \alpha, \beta \big)^T`
-            l (numbers.Number): Right boundary value of the domain :math:`[0,l]\ni z`.
+            param (array_like): Parameters
+                :math:`\big( a_2, a_1, a_0, \alpha, \beta \big)^T`
+            l (numbers.Number): Right boundary value of the domain
+                :math:`[0,l]\ni z`.
             n_roots (int): Amount of eigenfrequencies to compute.
             show_plot (bool): Show a plot window of the characteristic equation.
 
@@ -969,7 +972,7 @@ class SecondOrderRobinEigenfunction(Function, SecondOrderEigenfunction):
                            - omega) * np.sin(omega * l))
 
         # assume 1 root per pi/l (safety factor = 3)
-        search_begin = np.pi / l * .1
+        search_begin = 0
         search_end = 3 * n_roots * np.pi / l
         start_values_real = np.linspace(search_begin,
                                         search_end,

--- a/pyinduct/tests/test_eigenfunctions.py
+++ b/pyinduct/tests/test_eigenfunctions.py
@@ -361,14 +361,14 @@ class TestEigenvalues(unittest.TestCase):
 
 class TestSecondOrderRobinEigenvalueProblemFunctions(unittest.TestCase):
     def setUp(self):
-        self.param = [2, 1.5, -3, -5, -.5]
+        self.param = [60, 0, 0, 0.16666666666666666, 0.0033333333333333335]
         a2, a1, a0, alpha, beta = self.param
-        l = 1
+        l = 0.003
         limits = (0, l)
 
         self.spatial_domain = pi.Domain(limits, num=100)
         self.z = self.spatial_domain.points
-        self.n = 10
+        self.n = 4
 
         eig_freq, self.eig_val \
             = pi.SecondOrderRobinEigenfunction.eigfreq_eigval_hint(
@@ -376,6 +376,8 @@ class TestSecondOrderRobinEigenvalueProblemFunctions(unittest.TestCase):
                 l,
                 self.n,
                 show_plot=show_plots)
+        print(eig_freq)
+        print(self.eig_val)
 
         self.eig_funcs = np.array([pi.SecondOrderRobinEigenfunction(om,
                                                                     self.param,

--- a/pyinduct/tests/test_eigenfunctions.py
+++ b/pyinduct/tests/test_eigenfunctions.py
@@ -439,19 +439,19 @@ class TestSecondOrderRobinEigenvalueProblemFunctions(unittest.TestCase):
 
             # interval
             np.testing.assert_array_almost_equal(
-                self.a2_z(self.z) * self.eig_funcs[i].derive(2)(self.z)
+                (self.a2_z(self.z) * self.eig_funcs[i].derive(2)(self.z)
                 + self.a1_z(self.z) * eig_f.derive(1)(self.z)
-                + self.a0_z(self.z) * eig_f(self.z),
-                eig_v.real * eig_f(self.z),
-                decimal=2)
+                + self.a0_z(self.z) * eig_f(self.z)) / self.eig_val[i],
+                eig_v.real * eig_f(self.z) / self.eig_val[i],
+                decimal=4)
 
             # boundaries
-            self.assertTrue(np.isclose(eig_f.derive(1)(self.z[0]),
-                                       self.alpha * eig_f(self.z[0]),
-                                       atol=1e-4))
-            self.assertTrue(np.isclose(eig_f.derive(1)(self.z[-1]),
-                                       -self.beta * eig_f(self.z[-1]),
-                                       atol=1e-4))
+            np.testing.assert_array_almost_equal(
+                eig_f.derive(1)(self.z[0]) / self.eig_val[i],
+                self.alpha * eig_f(self.z[0]) / self.eig_val[i])
+            np.testing.assert_array_almost_equal(
+                eig_f.derive(1)(self.z[-1]) / self.eig_val[i],
+                -self.beta * eig_f(self.z[-1]) / self.eig_val[i])
 
 
 class IntermediateTransformationTest(unittest.TestCase):

--- a/pyinduct/tests/test_eigenfunctions.py
+++ b/pyinduct/tests/test_eigenfunctions.py
@@ -363,7 +363,7 @@ class TestSecondOrderRobinEigenvalueProblemFunctions(unittest.TestCase):
     def setUp(self):
         self.param = [2, 1.5, -3, -5, -.5]
         a2, a1, a0, alpha, beta = self.param
-        l = 1
+        l = 0.003
         limits = (0, l)
 
         self.spatial_domain = pi.Domain(limits, num=100)

--- a/pyinduct/tests/test_eigenfunctions.py
+++ b/pyinduct/tests/test_eigenfunctions.py
@@ -363,7 +363,7 @@ class TestSecondOrderRobinEigenvalueProblemFunctions(unittest.TestCase):
     def setUp(self):
         self.param = [2, 1.5, -3, -5, -.5]
         a2, a1, a0, alpha, beta = self.param
-        l = 1e3
+        l = 1
         limits = (0, l)
 
         self.spatial_domain = pi.Domain(limits, num=100)

--- a/pyinduct/tests/test_eigenfunctions.py
+++ b/pyinduct/tests/test_eigenfunctions.py
@@ -363,7 +363,7 @@ class TestSecondOrderRobinEigenvalueProblemFunctions(unittest.TestCase):
     def setUp(self):
         self.param = [2, 1.5, -3, -5, -.5]
         a2, a1, a0, alpha, beta = self.param
-        l = 0.003
+        l = 1e3
         limits = (0, l)
 
         self.spatial_domain = pi.Domain(limits, num=100)


### PR DESCRIPTION
The tests of the robin eigenfunctions fail for a short length. The first root isn't found corretctly.
The start value for the search is to high see [Line 984](https://github.com/TanDro/pyinduct/blob/79038d3915e5ecc5d694a3a826ee948fd37eb345/pyinduct/eigenfunctions.py#L984)

For a first fix I change the 0.1 to 0.001 and the correct first root is found, but the test still fails.