### PR TITLE
Some points about scalar product spaces

### DIFF
--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1903,7 +1903,7 @@ def normalize_base(b1, b2=None, mode="right"):
         ...     print("dot product: ", generic_scalar_product(b1n, b2n))
 
         is different by means of the normalized base *b1n* and *b2n*
-        but coinsides by the value of dot product:
+        but coincides by the value of dot product:
 
         >>> print_normalized_bases("right")
         ... # b1 normalized:  2

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1301,7 +1301,7 @@ def complex_quadrature(func, a, b, **kwargs):
 def dot_product(first, second):
     """
     Calculate the inner product of two vectors. Uses numpy.inner but with
-    complex conjugation of the first argument.
+    complex conjugation of the second argument.
 
     Args:
         first (:obj:`numpy.ndarray`): first vector
@@ -1317,17 +1317,17 @@ def dot_product_l2(first, second):
     r"""
     Calculate the inner product on L2.
 
-    Given two functions :math:`\varphi(z)` and :math:`\psi(z)` this functions
-    calculates
+    Given two functions :math:`\varphi(z)` (*first*) and :math:`\psi(z)`
+    (*second*) this functions calculates
 
     .. math::
         \left< \varphi(z) | \psi(z) \right> =
             \int\limits_{\Gamma_0}^{\Gamma_1}
-            \bar\varphi(\zeta) \psi(\zeta) \,\textup{d}\zeta \:.
+            \varphi(\zeta) \bar\psi(\zeta) \,\textup{d}\zeta \:.
 
     Args:
-        first (:py:class:`.Function`): first function
-        second (:py:class:`.Function`): second function
+        first (:py:class:`.Function`): first function :math:`\varphi(z)`
+        second (:py:class:`.Function`): second function :math:`\psi(z)`
 
     Return:
         inner product
@@ -1350,10 +1350,20 @@ def dot_product_l2(first, second):
     # standard case
     def func(z):
         """
-        Take the complex conjugate of the first element and multiply it
-        by the second.
+        Take the complex conjugate of the second element and multiply it
+        by the first.
         """
         return first(z) * np.conj(second(z))
+
+    for area in areas:
+        test_points = np.linspace(area[0], area[1])
+        first_num = first(test_points)
+        second_num = second(test_points)
+        if np.iscomplexobj(first_num) or np.iscomplexobj(second_num):
+            warnings.warn("Relevant if you used pyinduct<=0.5.* before:\n"
+            "The built-in l2 dot product (dot_product_l2) of pyinduct no \n"
+            "longer takes complex conjugation of the first argument but of\n"
+            "the second.")
 
     result, error = integrate_function(func, areas)
     return result

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1952,10 +1952,11 @@ def normalize_base(b1, b2=None, mode="right"):
     conj_factor = np.conj(factor)
     sc_1c = generic_scalar_product(b1.scale(factor), b2)
     sc_2c = generic_scalar_product(b1, b2.scale(factor))
-    if np.isclose(sc_1c, factor * res) and np.isclose(sc_2c, conj_factor * res):
+    if np.isclose(sc_1c, factor * res).all() \
+        and np.isclose(sc_2c, conj_factor * res).all():
         variant = "second_conjugated"
-    elif np.isclose(sc_1c, conj_factor * res) \
-            and np.isclose(sc_2c, factor * res):
+    elif np.isclose(sc_1c, conj_factor * res).all() \
+            and np.isclose(sc_2c, factor * res).all():
         variant = "first_conjugated"
     else:
         raise ValueError("Provided bases defines irregular scalar product")

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1342,11 +1342,6 @@ def dot_product_l2(first, second):
     nonzero = domain_intersection(first.nonzero, second.nonzero)
     areas = domain_intersection(first.domain, nonzero)
 
-    # try some shortcuts
-    if first == second:
-        if hasattr(first, "quad_int"):
-            return first.quad_int()
-
     if 0:
         # TODO let Function Class handle product to gain more speed
         if type(first) is type(second):

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -41,7 +41,7 @@ def sanitize_input(input_object, allowed_type):
         input_object
     """
     input_object = np.atleast_1d(input_object)
-    for obj in np.nditer(input_object, flags=["refs_ok"]):
+    for obj in np.nditer(input_object, flags=["refs_ok", "zerosize_ok"]):
         if not isinstance(obj.item(), allowed_type):
             raise TypeError("Only objects of type: {0} accepted.".format(allowed_type))
 

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1884,6 +1884,41 @@ def normalize_base(b1, b2=None, mode="right"):
     Return:
         :py:class:`.ApproximationBase` : if *b2* is None,
         otherwise: Tuple of 2 :py:class:`.ApproximationBase`'s.
+
+    Examples:
+        Consider the following two bases with only one finite
+        dimensional vector/fraction
+
+        >>> import pyinduct as pi
+        >>> b1 = pi.Base(pi.ComposedFunctionVector([], [2]))
+        >>> b2 = pi.Base(pi.ComposedFunctionVector([], [2j]))
+
+        depending on the *mode* kwarg the result of the normalization
+
+        >>> from pyinduct.core import generic_scalar_product
+        ... def print_normalized_bases(mode):
+        ...     b1n, b2n = pi.normalize_base(b1, b2, mode=mode)
+        ...     print("b1 normalized: ", b1n[0].get_member(0))
+        ...     print("b2 normalized: ", b2n[0].get_member(0))
+        ...     print("dot product: ", generic_scalar_product(b1n, b2n))
+
+        is different by means of the normalized base *b1n* and *b2n*
+        but coinsides by the value of dot product:
+
+        >>> print_normalized_bases("right")
+        ... # b1 normalized:  2
+        ... # b2 normalized:  (0.5-0j)
+        ... # dot product:  [1.]
+
+        >>> print_normalized_bases("left")
+        ... # b1 normalized:  (-0+0.5j)
+        ... # b2 normalized:  2j
+        ... # dot product:  [1.]
+
+        >>> print_normalized_bases("both")
+        ... # b1 normalized:  (0.7071067811865476+0.7071067811865476j)
+        ... # b2 normalized:  (0.7071067811865476+0.7071067811865476j)
+        ... # dot product:  [1.]
     """
     res = generic_scalar_product(b1, b2)
 

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1300,7 +1300,8 @@ def complex_quadrature(func, a, b, **kwargs):
 
 def dot_product(first, second):
     """
-    Calculate the inner product of two vectors.
+    Calculate the inner product of two vectors. Uses numpy.inner but with
+    complex conjugation of the first argument.
 
     Args:
         first (:obj:`numpy.ndarray`): first vector
@@ -1309,7 +1310,7 @@ def dot_product(first, second):
     Return:
         inner product
     """
-    return np.inner(first, second)
+    return np.inner(np.conj(first), second)
 
 
 def dot_product_l2(first, second):

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1371,8 +1371,12 @@ def dot_product_l2(first, second):
         return first(z) * np.conj(second(z))
 
     for area in areas:
-        test_points = np.linspace(area[0], area[1])
-        first_num = first(test_points)
+        test_point = area[0]
+        if test_point == -np.inf:
+            test_point = area[1]
+        if test_point == np.inf:
+            test_point = 0
+        first_num = first(test_point)
         if np.iscomplexobj(first_num):
             warnings.warn(
                 "The built-in l2 dot product (dot_product_l2) of pyinduct no \n"

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1358,12 +1358,12 @@ def dot_product_l2(first, second):
     for area in areas:
         test_points = np.linspace(area[0], area[1])
         first_num = first(test_points)
-        second_num = second(test_points)
-        if np.iscomplexobj(first_num) or np.iscomplexobj(second_num):
-            warnings.warn("Relevant if you used pyinduct<=0.5.* before:\n"
-            "The built-in l2 dot product (dot_product_l2) of pyinduct no \n"
-            "longer takes complex conjugation of the first argument but of\n"
-            "the second.")
+        if np.iscomplexobj(first_num):
+            warnings.warn(
+                "The built-in l2 dot product (dot_product_l2) of pyinduct no \n"
+                "longer takes complex conjugation of the first argument but "
+                "of the second."
+            )
 
     result, error = integrate_function(func, areas)
     return result

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1310,7 +1310,7 @@ def dot_product(first, second):
     Return:
         inner product
     """
-    return np.inner(np.conj(first), second)
+    return np.inner(first, np.conj(second))
 
 
 def dot_product_l2(first, second):
@@ -1353,7 +1353,7 @@ def dot_product_l2(first, second):
         Take the complex conjugate of the first element and multiply it
         by the second.
         """
-        return np.conj(first(z)) * second(z)
+        return first(z) * np.conj(second(z))
 
     result, error = integrate_function(func, areas)
     return result
@@ -1899,14 +1899,14 @@ def normalize_base(b1, b2=None, mode="right"):
         return scale_base_elementwise(b1, scale_factors)
     elif mode == "right":
         scale_factors = 1 / res
-        return b1, scale_base_elementwise(b2, scale_factors)
+        return b1, scale_base_elementwise(b2, np.conj(scale_factors))
     elif mode == "left":
         scale_factors = 1 / res
-        return scale_base_elementwise(b1, np.conj(scale_factors)), b2
+        return scale_base_elementwise(b1, scale_factors), b2
     elif mode == "both":
         scale_factors = np.real_if_close(np.sqrt(1 / res.astype(complex)))
-        return (scale_base_elementwise(b1, np.conj(scale_factors)),
-                scale_base_elementwise(b2, scale_factors))
+        return (scale_base_elementwise(b1, scale_factors),
+                scale_base_elementwise(b2, np.conj(scale_factors)))
     else:
         raise NotImplementedError
 

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -980,15 +980,30 @@ class Base(ApproximationBasis):
 
     def scale(self, factor):
         """
-        Factory method to obtain instances of this base, scaled by the given factor.
+        Return a scaled instance of this base.
+
+        If factor is iterable, each element will be scaled independently.
+        Otherwise, a common scaling is applied to all fractions.
 
         Args:
-            factor: factor or function to scale this base with.
+            factor: Single factor or iterable of factors (float or callable) to
+                scale this base with.
         """
-        if factor == 1:
-            return self
-        else:
-            return self.__class__([f.scale(factor) for f in self.fractions])
+        try:
+            if len(factor) != len(self.fractions):
+                raise ValueError("If factor is an iterable, its length has to"
+                                 "match the number of base fractions. "
+                                 "len(factor)={} but len(fractions)={}"
+                                 .format(len(factor), len(self.fractions)))
+            return self.__class__([
+                f.scale(s) for f, s in zip(self.fractions, factor)
+            ])
+        except TypeError:
+            # factor is not iterable
+            if factor == 1:
+                return self
+            else:
+                return self.__class__([f.scale(factor) for f in self.fractions])
 
     def raise_to(self, power):
         """

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1876,32 +1876,32 @@ def normalize_base(b1, b2=None):
         :py:class:`.ApproximationBase` : if *b2* is None,
         otherwise: Tuple of 2 :py:class:`.ApproximationBase`'s.
     """
+    res = generic_scalar_product(b1, b2)
+
+    if any(np.abs(res) < np.finfo(float).eps):
+        raise ValueError("given base fractions are orthogonal. "
+                         "no normalization possible.")
+
     auto_normalization = False
     if b2 is None:
         auto_normalization = True
-
-    res = generic_scalar_product(b1, b2)
-
-    if any(res < np.finfo(float).eps):
-        if any(np.isclose(res, 0)):
-            raise ValueError("given base fractions are orthogonal. "
-                             "no normalization possible.")
-        else:
+        res = np.real_if_close(res)
+        if any(res < 0) or np.imag(res) != 0:
             raise ValueError("imaginary scale required. "
                              "no normalization possible.")
 
-    scale_factors = np.sqrt(1 / res)
-    b1_scaled = b1.__class__(
-        [frac.scale(factor)
-         for frac, factor in zip(b1.fractions, scale_factors)])
-
     if auto_normalization:
+        scale_factors = np.sqrt(1 / res)
+        b1_scaled = b1.__class__(
+            [frac.scale(factor)
+             for frac, factor in zip(b1.fractions, scale_factors)])
         return b1_scaled
     else:
+        scale_factors = 1 / res
         b2_scaled = b2.__class__(
             [frac.scale(factor)
              for frac, factor in zip(b2.fractions, scale_factors)])
-        return b1_scaled, b2_scaled
+        return b1, b2_scaled
 
 
 def generic_scalar_product(b1, b2=None, scalar_product=None):

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1606,6 +1606,7 @@ class NormalizeBaseTestCase(unittest.TestCase):
         self.base_f = pi.Base(self.f)
         self.base_g = pi.Base(self.g)
         self.base_l = pi.Base(self.l)
+        self.base_fgl = pi.Base([self.f, self.g, self.l])
 
     def generic_test_function_single_base(self, b):
         bn = pi.normalize_base(b)
@@ -1617,6 +1618,7 @@ class NormalizeBaseTestCase(unittest.TestCase):
         self.generic_test_function_single_base(self.base_f)
         self.generic_test_function_single_base(self.base_g)
         self.generic_test_function_single_base(self.base_l)
+        self.generic_test_function_single_base(self.base_fgl)
         self.generic_test_function_single_base(self.base_l.scale(-1))
 
     def generic_test_function(self, b1, b2, mode):
@@ -1649,6 +1651,8 @@ class NormalizeBaseTestCase(unittest.TestCase):
 
     def test_scale(self):
         self.generic_test_wrapper(self.base_f, self.base_l)
+        self.generic_test_wrapper(self.base_fgl, self.base_fgl)
+        self.generic_test_wrapper(self.base_fgl, self.base_fgl.scale(4))
 
     def test_complex(self):
         self.generic_test_wrapper(self.base_g, self.base_l)

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1613,6 +1613,35 @@ class NormalizeBaseTestCase(unittest.TestCase):
         self.generic_test_wrapper(self.base_g.scale(1 + 2j),
                                   self.base_l.scale(1j))
 
+    def test_user_inner_product(self):
+        def my_dot_product_l2(first, second):
+            from pyinduct.core import domain_intersection
+            nonzero = domain_intersection(first.nonzero, second.nonzero)
+            areas = domain_intersection(first.domain, nonzero)
+
+            def func(z):
+                return np.conj(first(z)) * second(z)
+
+            from pyinduct.core import integrate_function
+            result, error = integrate_function(func, areas)
+            return result
+
+        class MyFunction(pi.Function):
+            def scalar_product_hint(self):
+                return my_dot_product_l2
+
+        g = MyFunction(np.cos, domain=(0, np.pi))
+        l = MyFunction(np.exp, domain=(0, np.pi))
+
+        base_g = pi.Base(g)
+        base_l = pi.Base(l)
+
+        self.generic_test_wrapper(base_g, base_l)
+        self.generic_test_wrapper(base_g, base_l.scale(1j))
+        self.generic_test_wrapper(base_g.scale(1 + 2j),
+                                  base_l.scale(1j))
+
+
     def test_culprits(self):
         # orthogonal
         with self.assertRaises(ValueError):

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1261,6 +1261,12 @@ class DotProductL2TestCase(unittest.TestCase):
                                           self.fem_base.scalar_product_hint())
         np.testing.assert_almost_equal(res, [1/3] + [2/3]*9 + [1/3])
 
+    def test_complex(self):
+        res = vectorize_scalar_product(self.fem_base.fractions,
+                                       self.fem_base.scale(1j).fractions,
+                                       self.fem_base.scalar_product_hint())
+        np.testing.assert_almost_equal(res, [-1j/3] + [-2j/3]*9 + [-1j/3])
+
 
 class CalculateScalarProductMatrixTestCase(unittest.TestCase):
     def setUp(self, dim1=10, dim2=20):

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -540,6 +540,15 @@ class BaseTestCase(unittest.TestCase):
         for a, b in zip(f.fractions, g2.fractions):
             np.testing.assert_array_equal(10 * a(values), b(values))
 
+        # if factors is iterable, then it has to match the number of fractions
+        with self.assertRaises(ValueError):
+            f.scale([1, 2])
+
+        factors = list(range(5))
+        g3 = f.scale(factors)
+        for a, b, s in zip(f.fractions, g3.fractions, factors):
+            np.testing.assert_array_equal(s * a(values), b(values))
+
     def test_scalar_product_hint(self):
         f = pi.Base(self.fractions)
 
@@ -1662,7 +1671,6 @@ class NormalizeBaseTestCase(unittest.TestCase):
         self.generic_test_wrapper(base_g, base_l.scale(1j))
         self.generic_test_wrapper(base_g.scale(1 + 2j),
                                   base_l.scale(1j))
-
 
     def test_culprits(self):
         # orthogonal

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1232,8 +1232,16 @@ class ScalarDotProductL2TestCase(unittest.TestCase):
     def test_complex(self):
         self.assertAlmostEqual(core.dot_product_l2(self.g1, self.g2), 40j)
         # swapping of args will return the conjugated expression
-        self.assertAlmostEqual(core.dot_product_l2(self.g2, self.g1),
-                               np.conj(40j))
+        # and should raise a warning since the behaviour has changed
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            r = core.dot_product_l2(self.g2, self.g1)
+            # we should have produced one warning
+            self.assertEqual(len(w), 1)
+            # we expect a user warning
+            self.assertTrue(issubclass(w[0].category, UserWarning))
+            self.assertIn("complex conjugation", str(w[0].message))
+        self.assertAlmostEqual(r, np.conj(40j))
 
     def test_linearity(self):
         factor = 2+1j

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1576,27 +1576,47 @@ class NormalizeBaseTestCase(unittest.TestCase):
         self.base_g = pi.Base(self.g)
         self.base_l = pi.Base(self.l)
 
-    def test_self_scale(self):
-        f = pi.normalize_base(self.base_f)
+    def generic_test_function_single_base(self, b):
+        bn = pi.normalize_base(b)
         prod = vectorize_scalar_product(
-            f.fractions, f.fractions, f.scalar_product_hint())[0]
+            bn.fractions, bn.fractions, bn.scalar_product_hint())[0]
         self.assertAlmostEqual(prod, 1)
+
+    def test_self_scale(self):
+        self.generic_test_function_single_base(self.base_f)
+        self.generic_test_function_single_base(self.base_g)
+        self.generic_test_function_single_base(self.base_l)
+        self.generic_test_function_single_base(self.base_l.scale(-1))
+
+    def generic_test_function(self, b1, b2, mode):
+        b1n, b2n = pi.normalize_base(b1, b2, mode)
+        prod = vectorize_scalar_product(
+            b1n.fractions, b2n.fractions, b1n.scalar_product_hint())[0]
+        self.assertAlmostEqual(prod, 1)
+
+        b1n, b2n = pi.normalize_base(b2, b1, mode)
+        prod = vectorize_scalar_product(
+            b1n.fractions, b2n.fractions, b2n.scalar_product_hint())[0]
+        self.assertAlmostEqual(prod, 1)
+
+    def generic_test_wrapper(self, b1, b2):
+        self.generic_test_function(b1, b2, mode="right")
+        self.generic_test_function(b1, b2, mode="left")
+        self.generic_test_function(b1, b2, mode="both")
 
     def test_scale(self):
-        f, l = pi.normalize_base(self.base_f, self.base_l)
-        prod = vectorize_scalar_product(
-            f.fractions, l.fractions, f.scalar_product_hint())[0]
-        self.assertAlmostEqual(prod, 1)
+        self.generic_test_wrapper(self.base_f, self.base_l)
 
     def test_complex(self):
-        g, l = pi.normalize_base(self.base_g, self.base_l)
-        prod = vectorize_scalar_product(
-            g.fractions, l.fractions, g.scalar_product_hint())[0]
-        self.assertAlmostEqual(prod, 1)
+        self.generic_test_wrapper(self.base_g, self.base_l)
+        self.generic_test_wrapper(self.base_g, self.base_l.scale(1j))
+        self.generic_test_wrapper(self.base_g.scale(1 + 2j),
+                                  self.base_l.scale(1j))
 
     def test_culprits(self):
         # orthogonal
-        self.assertRaises(ValueError, pi.normalize_base, self.base_f, self.base_g)
+        with self.assertRaises(ValueError):
+            pi.normalize_base(self.base_f, self.base_g)
 
 
 class FindRootsTestCase(unittest.TestCase):

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1222,16 +1222,16 @@ class ScalarDotProductL2TestCase(unittest.TestCase):
         self.assertAlmostEqual(core.dot_product_l2(self.f7, self.f6), 1 / 6)
 
     def test_complex(self):
-        self.assertAlmostEqual(core.dot_product_l2(self.g1, self.g2), -40j)
+        self.assertAlmostEqual(core.dot_product_l2(self.g1, self.g2), 40j)
         # swapping of args will return the conjugated expression
         self.assertAlmostEqual(core.dot_product_l2(self.g2, self.g1),
-                               np.conj(-40j))
+                               np.conj(40j))
 
     def test_linearity(self):
         factor = 2+1j
         s = self.g1.scale(factor)
-        res = core.dot_product_l2(s, self.g2)
-        part = core.dot_product_l2(self.g1, self.g2)
+        res = core.dot_product_l2(self.g2, s)
+        part = core.dot_product_l2(self.g2, self.g1)
         np.testing.assert_almost_equal(np.conjugate(factor)*part, res)
 
 
@@ -1240,8 +1240,8 @@ class DotProductTestCase(unittest.TestCase):
         self.assertEqual(dot_product(2, 3), 6)
 
     def test_sesquilinear(self):
-        self.assertEqual(dot_product(2j, 3), -6j)
-        self.assertEqual(dot_product(2, 3j), 6j)
+        self.assertEqual(dot_product(3, 2j), -6j)
+        self.assertEqual(dot_product(3j, 2), 6j)
 
 
 class DotProductL2TestCase(unittest.TestCase):

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1588,10 +1588,13 @@ class NormalizeBaseTestCase(unittest.TestCase):
             f.fractions, l.fractions, f.scalar_product_hint())[0]
         self.assertAlmostEqual(prod, 1)
 
-    def test_culprits(self):
-        # not possible
-        self.assertRaises(ValueError, pi.normalize_base, self.base_g, self.base_l)
+    def test_complex(self):
+        g, l = pi.normalize_base(self.base_g, self.base_l)
+        prod = vectorize_scalar_product(
+            g.fractions, l.fractions, g.scalar_product_hint())[0]
+        self.assertAlmostEqual(prod, 1)
 
+    def test_culprits(self):
         # orthogonal
         self.assertRaises(ValueError, pi.normalize_base, self.base_f, self.base_g)
 

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -9,7 +9,7 @@ from numbers import Number
 import numpy as np
 import pyinduct as pi
 import pyinduct.core as core
-from pyinduct.core import vectorize_scalar_product
+from pyinduct.core import vectorize_scalar_product, dot_product
 from pyinduct.tests import show_plots, test_timings
 from pyinduct.registry import clear_registry
 import pyqtgraph as pg
@@ -1233,6 +1233,15 @@ class ScalarDotProductL2TestCase(unittest.TestCase):
         res = core.dot_product_l2(s, self.g2)
         part = core.dot_product_l2(self.g1, self.g2)
         np.testing.assert_almost_equal(np.conjugate(factor)*part, res)
+
+
+class DotProductTestCase(unittest.TestCase):
+    def test_product(self):
+        self.assertEqual(dot_product(2, 3), 6)
+
+    def test_sesquilinear(self):
+        self.assertEqual(dot_product(2j, 3), -6j)
+        self.assertEqual(dot_product(2, 3j), 6j)
 
 
 class DotProductL2TestCase(unittest.TestCase):

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -21,6 +21,9 @@ class SanitizeInputTestCase(unittest.TestCase):
         pi.sanitize_input(1, int)
         pi.sanitize_input(1.0, float)
 
+    def test_zerosize(self):
+        pi.sanitize_input([], int)
+
 
 class BaseFractionTestCase(unittest.TestCase):
     def setUp(self):
@@ -350,6 +353,11 @@ class ComposedFunctionVectorTestCase(unittest.TestCase):
         v = pi.ComposedFunctionVector(self.functions[0], self.scalars[0])
         self.assertEqual(v.members["funcs"], [self.functions[0]])
         self.assertEqual(v.members["scalars"], [self.scalars[0]])
+
+        # test degenerated cases
+        pi.ComposedFunctionVector(self.functions[0], [])
+        # and also the more important one
+        pi.ComposedFunctionVector([], self.scalars[0])
 
     def test_get_member(self):
         v = pi.ComposedFunctionVector(self.functions, self.scalars)


### PR DESCRIPTION
The pr contains
* fix (3a86d34): Also the scalar inner procuct should be sesquilinear
* fix (3851159): Remove faulty dot product shortcut
* usability-improvement (a75434f): Switch complex conjugated element in inner product
* feature (0ea0781 + b6da3f6 + 6d8668e): Allow complex scales in normalize_base

Since it is not much fun to divide these things into different pr's and the first three points are quite manageable, I think this can be done in one throw.

At least the fix 3a86d34 should be considered for the next bug fix release, see #100.