### PR TITLE
Correct usage of scalar product matrix in project_on_base

### DIFF
--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1617,7 +1617,7 @@ def project_on_base(state, base):
     # compute <phi_i(z), phi_j(z)> for 0 < i, j < n (matrix)
     scale_mat = calculate_scalar_product_matrix(base, base)
 
-    res = np.linalg.inv(scale_mat) @ projections.T
+    res = np.linalg.inv(scale_mat.T) @ projections.T
     return np.reshape(res, (scale_mat.shape[0],))
 
 

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1569,7 +1569,7 @@ def calculate_scalar_product_matrix(base_a, base_b, scalar_product=None,
     if optimize and base_a == base_b:
         # since the scalar_product commutes whe can save some operations
         dim = fractions_a.shape[0]
-        output = np.zeros((dim, dim), dtype=np.complex)
+        output = np.zeros((dim, dim), dtype=complex)
         i, j = np.mgrid[0:dim, 0:dim]
 
         # compute only upper half

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1940,9 +1940,9 @@ def calculate_base_transformation_matrix(src_base, dst_base, scalar_product=None
         raise TypeError("Source and destination base must be from the same "
                         "type.")
 
-    p_mat = calculate_scalar_product_matrix(dst_base, src_base, scalar_product)
+    p_mat = calculate_scalar_product_matrix(src_base, dst_base, scalar_product).T
 
-    q_mat = calculate_scalar_product_matrix(dst_base, dst_base, scalar_product)
+    q_mat = calculate_scalar_product_matrix(dst_base, dst_base, scalar_product).T
 
     # compute V matrix, where V = inv(Q)*P
     v_mat = np.dot(np.linalg.inv(q_mat), p_mat)

--- a/pyinduct/core.py
+++ b/pyinduct/core.py
@@ -1596,12 +1596,12 @@ def calculate_scalar_product_matrix(base_a, base_b, scalar_product=None,
         return res.reshape(fractions_i.shape)
 
 
-def project_on_base(state, base):
+def project_on_base(state_vector, base):
     """
     Projects a *state* on a basis given by *base*.
 
     Args:
-        state (array_like): List of functions to approximate.
+        state_vector (array_like): List of functions to approximate.
         base (:py:class:`.ApproximationBase`): Basis to project onto.
 
     Return:
@@ -1611,14 +1611,14 @@ def project_on_base(state, base):
         raise TypeError("Projection only possible on approximation bases.")
 
     # compute <x(z, t), phi_i(z)> (vector)
-    projections = calculate_scalar_product_matrix(base.__class__(state),
+    projections = calculate_scalar_product_matrix(base.__class__(state_vector),
                                                   base)
 
     # compute <phi_i(z), phi_j(z)> for 0 < i, j < n (matrix)
     scale_mat = calculate_scalar_product_matrix(base, base)
 
     res = np.linalg.inv(scale_mat.T) @ projections.T
-    return np.reshape(res, (scale_mat.shape[0],))
+    return res.squeeze()
 
 
 def project_on_bases(states, canonical_equations):

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1672,6 +1672,24 @@ class ProjectionTest(unittest.TestCase):
                         symbol="+")
                 pi.show(show_mpl=False)
 
+    def test_complex_valued_base(self):
+        complex_base = pi.Base([f.scale(1j if i % 2 == 0 else 1)
+                                for i, f in enumerate(self.lag_base)])
+        weights = [pi.project_on_base(f, complex_base) for f in self.functions]
+        approxs = [pi.back_project_from_base(w, complex_base) for w in weights]
+        for i, (f, a) in enumerate(zip(self.functions, approxs)):
+            scale = 1 / 100 if i == 2 else 1
+            np.testing.assert_array_almost_equal(f(self.z_values) * scale,
+                                                 a(self.z_values) * scale,
+                                                 decimal=1)
+
+        if show_plots:
+            for f, a in zip(self.functions, approxs):
+                import matplotlib.pyplot as plt
+                plt.plot(self.z_values, f(self.z_values))
+                plt.plot(self.z_values, a(self.z_values))
+                plt.show()
+
     def tearDown(self):
         pi.deregister_base("lag_base")
         pi.deregister_base("comp_lag_base")

--- a/pyinduct/tests/test_core.py
+++ b/pyinduct/tests/test_core.py
@@ -1657,9 +1657,7 @@ class ProjectionTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(w, [2])
 
     def test_projection_on_lag1st(self):
-        weights = [pi.project_on_base(self.functions[1], self.lag_base),
-                   pi.project_on_base(self.functions[2], self.lag_base),
-                   pi.project_on_base(self.functions[3], self.lag_base)]
+        weights = pi.project_on_base(self.functions[1:], self.lag_base).T
 
         # linear function -> should be fitted exactly
         np.testing.assert_array_almost_equal(weights[0],
@@ -1700,9 +1698,8 @@ class ProjectionTest(unittest.TestCase):
             pi.show(show_mpl=False)
 
     def test_projection_on_composed_function_vector(self):
-        weights = [pi.project_on_base(self.func_vectors[idx],
-                                      self.comp_lag_base)
-                   for idx in [1, 2, 3]]
+        weights = pi.project_on_base(self.func_vectors[1:],
+                                     self.comp_lag_base).T
 
         # linear function -> should be fitted exactly
         np.testing.assert_array_almost_equal(weights[0],
@@ -1737,7 +1734,7 @@ class ProjectionTest(unittest.TestCase):
     def test_complex_valued_base(self):
         complex_base = pi.Base([f.scale(1j if i % 2 == 0 else 1)
                                 for i, f in enumerate(self.lag_base)])
-        weights = [pi.project_on_base(f, complex_base) for f in self.functions]
+        weights = pi.project_on_base(self.functions, complex_base).T
         approxs = [pi.back_project_from_base(w, complex_base) for w in weights]
         for i, (f, a) in enumerate(zip(self.functions, approxs)):
             scale = 1 / 100 if i == 2 else 1


### PR DESCRIPTION
The background is, that the calculation of the scalar product matrix for equal bases is not as easy as assumed at a first glance, due to the semi-linear property of the scalar product.

I created a pr, since this is not the only usage of `calculate_scalar_product_matrix`.